### PR TITLE
Implement basic subscribe/publish mqtt functionality

### DIFF
--- a/app/src/main/java/se/hkr/smarthouse/di/ActivityBuildersModule.kt
+++ b/app/src/main/java/se/hkr/smarthouse/di/ActivityBuildersModule.kt
@@ -6,6 +6,10 @@ import se.hkr.smarthouse.di.auth.AuthFragmentsBuildersModule
 import se.hkr.smarthouse.di.auth.AuthModule
 import se.hkr.smarthouse.di.auth.AuthScope
 import se.hkr.smarthouse.di.auth.AuthViewModelModule
+import se.hkr.smarthouse.di.main.MainFragmentsBuildersModule
+import se.hkr.smarthouse.di.main.MainModule
+import se.hkr.smarthouse.di.main.MainScope
+import se.hkr.smarthouse.di.main.MainViewModelModule
 import se.hkr.smarthouse.ui.auth.AuthActivity
 import se.hkr.smarthouse.ui.main.MainActivity
 
@@ -22,6 +26,14 @@ abstract class ActivityBuildersModule {
     )
     abstract fun contributeAuthActivity(): AuthActivity
 
-    @ContributesAndroidInjector
+    // Creating the MainScope
+    @MainScope
+    @ContributesAndroidInjector(
+        modules = [
+            MainModule::class,
+            MainFragmentsBuildersModule::class,
+            MainViewModelModule::class
+        ]
+    )
     abstract fun contributeMainActivity(): MainActivity
 }

--- a/app/src/main/java/se/hkr/smarthouse/di/main/MainFragmentsBuildersModule.kt
+++ b/app/src/main/java/se/hkr/smarthouse/di/main/MainFragmentsBuildersModule.kt
@@ -1,0 +1,11 @@
+package se.hkr.smarthouse.di.main
+
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+import se.hkr.smarthouse.ui.main.HouseFragment
+
+@Module
+abstract class MainFragmentsBuildersModule {
+    @ContributesAndroidInjector
+    abstract fun contributeHouseFragment(): HouseFragment
+}

--- a/app/src/main/java/se/hkr/smarthouse/di/main/MainModule.kt
+++ b/app/src/main/java/se/hkr/smarthouse/di/main/MainModule.kt
@@ -1,0 +1,22 @@
+package se.hkr.smarthouse.di.main
+
+import dagger.Module
+import dagger.Provides
+import se.hkr.smarthouse.persistence.AccountCredentialsDao
+import se.hkr.smarthouse.repository.main.MainRepository
+import se.hkr.smarthouse.session.SessionManager
+
+@Module
+class MainModule {
+    @MainScope
+    @Provides
+    fun provideMainRepository(
+        sessionManager: SessionManager,
+        accountCredentialsDao: AccountCredentialsDao
+    ): MainRepository {
+        return MainRepository(
+            sessionManager = sessionManager,
+            accountCredentialsDao = accountCredentialsDao
+        )
+    }
+}

--- a/app/src/main/java/se/hkr/smarthouse/di/main/MainScope.kt
+++ b/app/src/main/java/se/hkr/smarthouse/di/main/MainScope.kt
@@ -1,0 +1,7 @@
+package se.hkr.smarthouse.di.main
+
+import javax.inject.Scope
+
+@Scope
+@kotlin.annotation.Retention(AnnotationRetention.RUNTIME)
+annotation class MainScope

--- a/app/src/main/java/se/hkr/smarthouse/di/main/MainViewModelModule.kt
+++ b/app/src/main/java/se/hkr/smarthouse/di/main/MainViewModelModule.kt
@@ -1,0 +1,16 @@
+package se.hkr.smarthouse.di.main
+
+import androidx.lifecycle.ViewModel
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+import se.hkr.smarthouse.di.ViewModelKey
+import se.hkr.smarthouse.ui.main.MainViewModel
+
+@Module
+abstract class MainViewModelModule {
+    @Binds
+    @IntoMap
+    @ViewModelKey(MainViewModel::class)
+    abstract fun bindAuthViewModel(mainViewModel: MainViewModel): ViewModel
+}

--- a/app/src/main/java/se/hkr/smarthouse/models/AccountCredentials.kt
+++ b/app/src/main/java/se/hkr/smarthouse/models/AccountCredentials.kt
@@ -3,7 +3,7 @@ package se.hkr.smarthouse.models
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.util.*
+import java.util.UUID
 
 @Entity(
     tableName = "account_credential"

--- a/app/src/main/java/se/hkr/smarthouse/mqtt/MqttConnection.kt
+++ b/app/src/main/java/se/hkr/smarthouse/mqtt/MqttConnection.kt
@@ -5,13 +5,35 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.eclipse.paho.client.mqttv3.MqttClient
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 import se.hkr.smarthouse.mqtt.responses.MqttResponse
-import java.util.*
+import java.util.UUID
 
 object MqttConnection {
     val TAG: String = "AppDebug"
-    var mqttClient: MqttClient? = null
+    lateinit var mqttClient: MqttClient
+
+    fun publish(
+        topic: String,
+        message: String,
+        qos: Int
+    ): LiveData<MqttResponse> {
+        val liveData = MutableLiveData<MqttResponse>()
+        try {
+            Log.d(TAG, "MqttConnection: publishing: topic: $topic, message: $message, qos: $qos")
+            val mqttMessage = MqttMessage(message.toByteArray())
+            mqttMessage.qos = qos
+            mqttClient.publish(topic, mqttMessage)
+            liveData.value = MqttResponse(true)
+            Log.d(TAG, "Mqtt connection success")
+        } catch (e: Exception) {
+            liveData.value = MqttResponse(false)
+            Log.e(TAG, "Mqtt connection failure")
+            Log.e(TAG, "Exception stack trace: ", e)
+        }
+        return liveData
+    }
 
     fun connect(
         username: String,
@@ -30,7 +52,7 @@ object MqttConnection {
             // To be used when authentication is required
             // connectionOptions.userName = username
             // connectionOptions.password = password.toCharArray()
-            mqttClient!!.connect(connectionOptions)
+            mqttClient.connect(connectionOptions)
             liveData.value = MqttResponse(true)
             Log.d(TAG, "Mqtt connection success")
         } catch (e: Exception) {

--- a/app/src/main/java/se/hkr/smarthouse/repository/main/MainRepository.kt
+++ b/app/src/main/java/se/hkr/smarthouse/repository/main/MainRepository.kt
@@ -1,0 +1,94 @@
+package se.hkr.smarthouse.repository.main
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import kotlinx.coroutines.Job
+import se.hkr.smarthouse.mqtt.MqttConnection
+import se.hkr.smarthouse.mqtt.responses.MqttResponse
+import se.hkr.smarthouse.persistence.AccountCredentialsDao
+import se.hkr.smarthouse.repository.NetworkBoundResource
+import se.hkr.smarthouse.session.SessionManager
+import se.hkr.smarthouse.ui.DataState
+import se.hkr.smarthouse.ui.Response
+import se.hkr.smarthouse.ui.ResponseType
+import se.hkr.smarthouse.ui.main.state.LampState
+import se.hkr.smarthouse.ui.main.state.MainViewState
+import se.hkr.smarthouse.ui.main.state.PublishFields
+import javax.inject.Inject
+
+class MainRepository
+@Inject
+constructor(
+    val sessionManager: SessionManager,
+    val accountCredentialsDao: AccountCredentialsDao // Potentially don't need this here
+) {
+    val TAG = "AppDebug"
+    private var repositoryJob: Job? = null
+
+    fun attemptPublish(
+        topic: String,
+        message: String,
+        qos: Int
+    ): LiveData<DataState<MainViewState>> {
+        val loginFieldErrors = PublishFields(topic, message, qos).isValidForPublish()
+        if (loginFieldErrors != PublishFields.PublishError.none()) {
+            return returnErrorResponse(loginFieldErrors, ResponseType.Dialog())
+        }
+        return object : NetworkBoundResource<MqttResponse, MainViewState>(
+            sessionManager.isConnectedToTheInternet()
+        ) {
+            override fun handleResponse(response: MqttResponse) {
+                Log.d(TAG, "handle response: $response")
+                if (!response.successful) {
+                    return onErrorReturn("Connection Failed", true, false)
+                }
+                onCompleteJob(
+                    DataState.data(
+                        data = MainViewState(
+                            lampState = LampState(
+                                state = message == "true" // TODO Change message to work differently?
+                            )
+                        )
+                    )
+                )
+            }
+
+            override fun createCall(): LiveData<MqttResponse> {
+                return MqttConnection.publish(
+                    topic = topic,
+                    message = message,
+                    qos = qos
+                )
+            }
+
+            override fun setJob(job: Job) {
+                cancelActiveJobs()
+                repositoryJob = job
+            }
+        }.asLiveData()
+    }
+
+    private fun returnErrorResponse(
+        errorMessage: String,
+        responseType: ResponseType
+    ): LiveData<DataState<MainViewState>> {
+        Log.d(TAG, "returnErrorMessage: $errorMessage")
+        return object : LiveData<DataState<MainViewState>>() {
+            override fun onActive() {
+                super.onActive()
+                value = DataState.error(
+                    Response(
+                        message = errorMessage,
+                        responseType = responseType
+                    )
+                )
+            }
+        }
+    }
+
+    fun cancelActiveJobs() {
+        // Cancel all old jobs
+        Log.d(TAG, "AuthRepository: Cancelling ongoing jobs")
+        repositoryJob?.cancel()
+    }
+}

--- a/app/src/main/java/se/hkr/smarthouse/ui/auth/AuthActivity.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/auth/AuthActivity.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import kotlinx.android.synthetic.main.activity_auth.progress_bar
+import kotlinx.android.synthetic.main.activity_auth.*
 import se.hkr.smarthouse.R
 import se.hkr.smarthouse.ui.BaseActivity
 import se.hkr.smarthouse.ui.auth.state.LoginFields

--- a/app/src/main/java/se/hkr/smarthouse/ui/auth/LauncherFragment.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/auth/LauncherFragment.kt
@@ -5,10 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
-import kotlinx.android.synthetic.main.fragment_launcher.focusable_view
-import kotlinx.android.synthetic.main.fragment_launcher.forgot_password
-import kotlinx.android.synthetic.main.fragment_launcher.login
-import kotlinx.android.synthetic.main.fragment_launcher.register
+import kotlinx.android.synthetic.main.fragment_launcher.*
 import se.hkr.smarthouse.R
 
 class LauncherFragment : BaseAuthFragment() {

--- a/app/src/main/java/se/hkr/smarthouse/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/auth/LoginFragment.kt
@@ -5,10 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.fragment_login.input_host_url
-import kotlinx.android.synthetic.main.fragment_login.input_password
-import kotlinx.android.synthetic.main.fragment_login.input_username
-import kotlinx.android.synthetic.main.fragment_login.login_button
+import kotlinx.android.synthetic.main.fragment_login.*
 import se.hkr.smarthouse.R
 import se.hkr.smarthouse.ui.auth.state.AuthStateEvent
 import se.hkr.smarthouse.ui.auth.state.LoginFields

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/BaseMainFragment.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/BaseMainFragment.kt
@@ -1,0 +1,25 @@
+package se.hkr.smarthouse.ui.main
+
+import android.os.Bundle
+import android.view.View
+import androidx.lifecycle.ViewModelProvider
+import dagger.android.support.DaggerFragment
+import se.hkr.smarthouse.viewmodels.ViewModelProviderFactory
+import javax.inject.Inject
+
+abstract class BaseMainFragment : DaggerFragment() {
+    companion object {
+        const val TAG: String = "AppDebug"
+    }
+
+    @Inject
+    lateinit var providerFactory: ViewModelProviderFactory
+    lateinit var viewModel: MainViewModel
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = activity?.let { context ->
+            ViewModelProvider(context, providerFactory).get(MainViewModel::class.java)
+        } ?: throw Exception("Invalid Activity")
+    }
+}

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/HouseFragment.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/HouseFragment.kt
@@ -1,0 +1,77 @@
+package se.hkr.smarthouse.ui.main
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CompoundButton
+import androidx.lifecycle.Observer
+import kotlinx.android.synthetic.main.fragment_house.*
+import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import se.hkr.smarthouse.R
+import se.hkr.smarthouse.ui.main.state.MainStateEvent
+
+class HouseFragment : BaseMainFragment() {
+    private val switchStateListener: CompoundButton.OnCheckedChangeListener =
+        CompoundButton.OnCheckedChangeListener { _, isChecked ->
+            publishTopic(isChecked)
+        }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_house, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        subscribeObservers()
+        state_switch.setOnCheckedChangeListener(switchStateListener)
+        subscribe_button.setOnClickListener {
+            subscribeTopic()
+        }
+    }
+
+    private fun subscribeObservers() {
+        viewModel.viewState.observe(viewLifecycleOwner, Observer { mainViewState ->
+            try {
+                Log.d(TAG, "HouseFragment: new viewState $mainViewState")
+                mainViewState.lampState?.let { lampState ->
+                    GlobalScope.launch(Main) {
+                        state_switch.setOnCheckedChangeListener(null)
+                        state_switch.isChecked = lampState.state
+                        // TODO test if the removal/adding of the listener works as intended.
+                        state_switch.setOnCheckedChangeListener(switchStateListener)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Exception on viewState observing on fragment", e)
+            }
+        })
+    }
+
+    private fun publishTopic(state: Boolean) {
+        Log.d(TAG, "flipped to $state")
+        viewModel.setStateEvent(
+            MainStateEvent.PublishAttemptEvent(
+                topic = input_topic.text.toString(),
+                message = if (state) "true" else "false",
+                qos = 2 // TODO add variable for QOS
+            )
+        )
+    }
+
+    private fun subscribeTopic() {
+        // TODO do this with event, for now just hard code it
+        //viewModel.setStateEvent(
+        //    MainStateEvent.SubscribeAttemptEvent(
+        //        input_topic.text.toString()
+        //    )
+        //)
+        viewModel.subscribeTo(topic = input_topic.text.toString())
+    }
+}

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
@@ -4,25 +4,67 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.activity_main.progress_bar
-import kotlinx.android.synthetic.main.activity_main.tool_bar
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.android.synthetic.main.activity_main.*
 import se.hkr.smarthouse.R
+import se.hkr.smarthouse.mqtt.MqttConnection
 import se.hkr.smarthouse.ui.BaseActivity
 import se.hkr.smarthouse.ui.auth.AuthActivity
 import se.hkr.smarthouse.util.setVisibility
+import se.hkr.smarthouse.viewmodels.ViewModelProviderFactory
+import javax.inject.Inject
 
 class MainActivity : BaseActivity() {
+    @Inject
+    lateinit var providerFactory: ViewModelProviderFactory
+    private lateinit var viewModel: MainViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        viewModel = ViewModelProvider(this, providerFactory).get(MainViewModel::class.java)
         tool_bar.setOnClickListener {
             // Temporary
             sessionManager.logout()
         }
         subscribeObservers()
+        // TODO use nav for it instead of this simple inflation
+        supportFragmentManager.beginTransaction()
+            .replace(
+                R.id.fragment_container,
+                HouseFragment(),
+                "HouseFragment"
+            ).commit()
     }
 
     private fun subscribeObservers() {
+        viewModel.dataState.observe(this, Observer { dataState ->
+            Log.d(TAG, "MainActivity: dataState changed: $dataState")
+            onDataStateChange(dataState)
+            dataState.data?.let { data ->
+                data.data?.let { dataEvent ->
+                    dataEvent.getContentIfNotHandled()?.let { eventContent ->
+                        eventContent.publishFields?.let { publishFields ->
+                            Log.d(TAG, "MainActivity: new publishFields: $publishFields")
+                            viewModel.setPublishFields(publishFields)
+                        }
+                    }
+                }
+            }
+        })
+        viewModel.viewState.observe(this, Observer { authViewState ->
+            Log.d(TAG, "MainActivity: viewState changed to: $authViewState")
+            authViewState.publishFields?.let { publishFields ->
+                publishFields.topic?.let {
+                    MqttConnection.publish(
+                        // TODO not just !!, check how to fix this properly
+                        publishFields.topic!!,
+                        publishFields.message!!,
+                        publishFields.qos
+                    )
+                }
+            }
+        })
         sessionManager.cachedAccountCredentials.observe(this, Observer { accountCredentials ->
             Log.d(TAG, "MainActivity: Account credentials observed change: $accountCredentials")
             if (accountCredentials == null

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainViewModel.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainViewModel.kt
@@ -1,0 +1,80 @@
+package se.hkr.smarthouse.ui.main
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import se.hkr.smarthouse.mqtt.MqttConnection
+import se.hkr.smarthouse.repository.main.MainRepository
+import se.hkr.smarthouse.ui.BaseViewModel
+import se.hkr.smarthouse.ui.DataState
+import se.hkr.smarthouse.ui.main.state.LampState
+import se.hkr.smarthouse.ui.main.state.MainStateEvent
+import se.hkr.smarthouse.ui.main.state.MainViewState
+import se.hkr.smarthouse.ui.main.state.PublishFields
+import se.hkr.smarthouse.ui.main.state.SubscribeFields
+import se.hkr.smarthouse.util.AbsentLiveData
+import javax.inject.Inject
+
+class MainViewModel
+@Inject
+constructor(
+    val mainRepository: MainRepository
+) : BaseViewModel<MainStateEvent, MainViewState>() {
+    override fun handleStateEvent(stateEvent: MainStateEvent): LiveData<DataState<MainViewState>> {
+        // Temporary until the functionality is fixed
+        when (stateEvent) {
+            is MainStateEvent.PublishAttemptEvent -> {
+                return mainRepository.attemptPublish(
+                    stateEvent.topic,
+                    stateEvent.message,
+                    stateEvent.qos
+                )
+            }
+            is MainStateEvent.SubscribeAttemptEvent -> {
+                // TODO Implement subscribe using MVI as well
+                return AbsentLiveData.create<DataState<MainViewState>>()
+            }
+        }
+    }
+
+    override fun initNewViewState(): MainViewState {
+        return MainViewState()
+    }
+
+    fun subscribeTo(topic: String) {
+        // TODO avoid breaking the MVI patter
+        Log.d(TAG, "Subscribing to $topic")
+        MqttConnection.mqttClient.subscribe(topic) { subscribedTopic, messageReceived ->
+            val received = messageReceived.toString()
+            Log.d(TAG, "Got: $received")
+            val state = received == "true"
+            _viewState.postValue(MainViewState(lampState = LampState(state)))
+        }
+    }
+
+    fun setPublishFields(publishFields: PublishFields) {
+        val newViewState = getCurrentViewStateOrNew()
+        if (newViewState.publishFields == publishFields) {
+            return
+        }
+        newViewState.publishFields = publishFields
+        _viewState.value = newViewState
+    }
+
+    fun setSubscribeFields(subscribeFields: SubscribeFields) {
+        val newViewState = getCurrentViewStateOrNew()
+        if (newViewState.subscribeFields == subscribeFields) {
+            return
+        }
+        newViewState.subscribeFields = subscribeFields
+        _viewState.value = newViewState
+    }
+
+    fun cancelActiveJobs() {
+        mainRepository.cancelActiveJobs()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        cancelActiveJobs()
+    }
+}

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainStateEvent.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainStateEvent.kt
@@ -1,0 +1,13 @@
+package se.hkr.smarthouse.ui.main.state
+
+sealed class MainStateEvent {
+    data class SubscribeAttemptEvent(
+        val topic: String
+    ) : MainStateEvent()
+
+    data class PublishAttemptEvent(
+        val topic: String,
+        val message: String,
+        val qos: Int
+    ) : MainStateEvent()
+}

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainViewState.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainViewState.kt
@@ -1,0 +1,56 @@
+package se.hkr.smarthouse.ui.main.state
+
+data class MainViewState(
+    var subscribeFields: SubscribeFields? = SubscribeFields(),
+    var publishFields: PublishFields? = PublishFields(),
+    var lampState: LampState? = LampState() // TODO add more (all?) states
+)
+
+data class LampState(
+    var state: Boolean = false
+)
+
+data class SubscribeFields(
+    var topic: String? = null
+) {
+    // TODO implement this as well
+}
+
+data class PublishFields(
+    var topic: String? = null,
+    var message: String? = null,
+    var qos: Int = -1
+) {
+    class PublishError {
+        companion object {
+            fun mustFillAllFields(): String {
+                return "You publish without all fields."
+            }
+
+            fun mustUseCorrectQos(): String {
+                return "Qos must be 0, 1 or 2"
+            }
+
+            fun none(): String {
+                return "None."
+            }
+        }
+    }
+
+    fun isValidForPublish(): String {
+        if (topic.isNullOrEmpty()
+            || message.isNullOrEmpty()
+            || qos == -1
+        ) {
+            return PublishError.mustFillAllFields()
+        }
+        if (qos < 0 || qos > 2) {
+            return PublishError.mustUseCorrectQos()
+        }
+        return PublishError.none()
+    }
+
+    override fun toString(): String {
+        return "PublishFields(topic=$topic, message=$message, qos=$qos)"
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,6 +28,12 @@
         android:layout_height="match_parent"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
+        <!--Temporary!-->
+        <FrameLayout
+            android:id="@+id/fragment_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
         <FrameLayout
             android:id="@+id/main_nav_host_fragment"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_house.xml
+++ b/app/src/main/res/layout/fragment_house.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.main.MainActivity">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/input_topic_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHorizontal"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineVertical"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHorizontal"
+        app:layout_constraintVertical_bias="0.0">
+
+        <EditText
+            android:id="@+id/input_topic"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/topic"
+            android:inputType="text"
+            android:text="home/garden/fountain"
+            android:textAlignment="center"
+            android:textColor="#000" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <Button
+        android:id="@+id/subscribe_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="15dp"
+        android:background="@drawable/main_button_drawable"
+        android:text="@string/subscribe"
+        android:textAllCaps="false"
+        android:textColor="#fff"
+        android:textSize="16sp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_topic_layout" />
+
+    <Switch
+        android:id="@+id/state_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHorizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertical"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHorizontal">
+
+    </Switch>
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHorizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineVertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.8" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,6 @@
     <string name="text_ok">OK</string>
     <string name="text_error">Error</string>
     <string name="host_url">Host Url</string>
+    <string name="topic">Topic</string>
+    <string name="subscribe">Subscribe</string>
 </resources>


### PR DESCRIPTION
Update Dagger to work for the Main part of the app as well.
Publish uses MVI pattern almost perfectly, some refinement may be
needed.
Subscribe currently just interacts with the ViewModel directly and
updates the viewState directly as well, as a proof of concept before
meeting #4 with the teachers.
Main Activity also implements a temporary fragment which is simply
inflated and is used to subscribe/publish to a true/false topic (proof
of concept for an on/off lamp for example).