### PR TITLE
Feature smarthouse device recycler view

### DIFF
--- a/.idea/dictionaries/STGA0006.xml
+++ b/.idea/dictionaries/STGA0006.xml
@@ -4,6 +4,7 @@
       <w>coroutine</w>
       <w>coroutines</w>
       <w>mqtt</w>
+      <w>smarthome</w>
       <w>smarthouse</w>
       <w>viewmodel</w>
     </words>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
 
     // Room
-    def room_version = "2.2.0-rc01"
+    def room_version = "2.2.1"
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 
@@ -113,7 +113,8 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.navigation:navigation-runtime:$nav_version"
 
-    def material_version = "1.1.0-alpha09"
+    // Google material design
+    def material_version = "1.2.0-alpha01"
     implementation "com.google.android.material:material:$material_version"
 
     // Material dialogs

--- a/app/src/main/java/se/hkr/smarthouse/di/main/MainFragmentsBuildersModule.kt
+++ b/app/src/main/java/se/hkr/smarthouse/di/main/MainFragmentsBuildersModule.kt
@@ -2,10 +2,10 @@ package se.hkr.smarthouse.di.main
 
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
-import se.hkr.smarthouse.ui.main.HouseFragment
+import se.hkr.smarthouse.ui.main.MainFragment
 
 @Module
 abstract class MainFragmentsBuildersModule {
     @ContributesAndroidInjector
-    abstract fun contributeHouseFragment(): HouseFragment
+    abstract fun contributeHouseFragment(): MainFragment
 }

--- a/app/src/main/java/se/hkr/smarthouse/di/main/MainModule.kt
+++ b/app/src/main/java/se/hkr/smarthouse/di/main/MainModule.kt
@@ -2,7 +2,6 @@ package se.hkr.smarthouse.di.main
 
 import dagger.Module
 import dagger.Provides
-import se.hkr.smarthouse.persistence.AccountCredentialsDao
 import se.hkr.smarthouse.repository.main.MainRepository
 import se.hkr.smarthouse.session.SessionManager
 
@@ -11,12 +10,10 @@ class MainModule {
     @MainScope
     @Provides
     fun provideMainRepository(
-        sessionManager: SessionManager,
-        accountCredentialsDao: AccountCredentialsDao
+        sessionManager: SessionManager
     ): MainRepository {
         return MainRepository(
-            sessionManager = sessionManager,
-            accountCredentialsDao = accountCredentialsDao
+            sessionManager = sessionManager
         )
     }
 }

--- a/app/src/main/java/se/hkr/smarthouse/models/Device.kt
+++ b/app/src/main/java/se/hkr/smarthouse/models/Device.kt
@@ -1,56 +1,103 @@
 package se.hkr.smarthouse.models
 
+import android.util.Log
+import se.hkr.smarthouse.mqtt.Topics
+
+const val TAG = "AppDebug"
+
 sealed class Device(
     open val topic: String
 ) {
+    companion object {
+        fun builder(topic: String, message: String): Device {
+            return when (Topics.hashMap[topic]) {
+                is InteractiveOnOff.Companion -> {
+                    InteractiveOnOff(topic = topic, state = message == "true")
+                }
+                is ObservableOnOff.Companion -> {
+                    ObservableOnOff(topic = topic, state = message == "true")
+                }
+                is InteractiveTemperature.Companion -> {
+                    InteractiveTemperature(topic = topic, temperature = message.toFloat())
+                }
+                is ObservableTemperature.Companion -> {
+                    ObservableTemperature(topic = topic, temperature = message.toFloat())
+                }
+                is InteractiveRgb.Companion -> {
+                    // Assumes format of "128 50 34" aka "R G B" where R is the number of Red etc.
+                    val colorsSplit = message.split(" ")
+                    InteractiveRgb(
+                        topic = topic,
+                        red = colorsSplit[0].toInt(),
+                        green = colorsSplit[1].toInt(),
+                        blue = colorsSplit[2].toInt()
+                    )
+                }
+                else -> {
+                    Log.e(TAG, "Device, unknown device type, check the hashMap values maybe")
+                    UnknownDevice(topic, message)
+                }
+            }
+        }
+    }
+
     fun getName(): String {
         return topic.split("/").last()
     }
-}
 
-data class InteractiveOnOff(
-    override val topic: String,
-    var state: Boolean = false
-) : Device(topic) {
-    companion object {
-        const val IDENTIFIER = 0
+    data class UnknownDevice(
+        override val topic: String,
+        var message: String = ""
+    ) : Device(topic) {
+        companion object {
+            const val IDENTIFIER = -1
+        }
     }
-}
 
-data class ObservableOnOff(
-    override val topic: String,
-    var state: Boolean = false
-) : Device(topic) {
-    companion object {
-        const val IDENTIFIER = 1
+    data class InteractiveOnOff(
+        override val topic: String,
+        var state: Boolean = false
+    ) : Device(topic) {
+        companion object {
+            const val IDENTIFIER = 0
+        }
     }
-}
 
-data class InteractiveTemperature(
-    override val topic: String,
-    var temperature: Float = 0f
-) : Device(topic) {
-    companion object {
-        const val IDENTIFIER = 2
+    data class ObservableOnOff(
+        override val topic: String,
+        var state: Boolean = false
+    ) : Device(topic) {
+        companion object {
+            const val IDENTIFIER = 1
+        }
     }
-}
 
-data class ObservableTemperature(
-    override val topic: String,
-    var temperature: Float = 0f
-) : Device(topic) {
-    companion object {
-        const val IDENTIFIER = 3
+    data class InteractiveTemperature(
+        override val topic: String,
+        var temperature: Float = 0f
+    ) : Device(topic) {
+        companion object {
+            const val IDENTIFIER = 2
+        }
     }
-}
 
-data class InteractiveRgb(
-    override val topic: String,
-    var red: Int = 0,
-    var green: Int = 0,
-    var blue: Int = 0
-) : Device(topic) {
-    companion object {
-        const val IDENTIFIER = 4
+    data class ObservableTemperature(
+        override val topic: String,
+        var temperature: Float = 0f
+    ) : Device(topic) {
+        companion object {
+            const val IDENTIFIER = 3
+        }
+    }
+
+    data class InteractiveRgb(
+        override val topic: String,
+        var red: Int = 0,
+        var green: Int = 0,
+        var blue: Int = 0
+    ) : Device(topic) {
+        companion object {
+            const val IDENTIFIER = 4
+        }
     }
 }

--- a/app/src/main/java/se/hkr/smarthouse/models/Device.kt
+++ b/app/src/main/java/se/hkr/smarthouse/models/Device.kt
@@ -1,0 +1,56 @@
+package se.hkr.smarthouse.models
+
+sealed class Device(
+    open val topic: String
+) {
+    fun getName(): String {
+        return topic.split("/").last()
+    }
+}
+
+data class InteractiveOnOff(
+    override val topic: String,
+    var state: Boolean = false
+) : Device(topic) {
+    companion object {
+        const val IDENTIFIER = 0
+    }
+}
+
+data class ObservableOnOff(
+    override val topic: String,
+    var state: Boolean = false
+) : Device(topic) {
+    companion object {
+        const val IDENTIFIER = 1
+    }
+}
+
+data class InteractiveTemperature(
+    override val topic: String,
+    var temperature: Float = 0f
+) : Device(topic) {
+    companion object {
+        const val IDENTIFIER = 2
+    }
+}
+
+data class ObservableTemperature(
+    override val topic: String,
+    var temperature: Float = 0f
+) : Device(topic) {
+    companion object {
+        const val IDENTIFIER = 3
+    }
+}
+
+data class InteractiveRgb(
+    override val topic: String,
+    var red: Int = 0,
+    var green: Int = 0,
+    var blue: Int = 0
+) : Device(topic) {
+    companion object {
+        const val IDENTIFIER = 4
+    }
+}

--- a/app/src/main/java/se/hkr/smarthouse/mqtt/MqttConnection.kt
+++ b/app/src/main/java/se/hkr/smarthouse/mqtt/MqttConnection.kt
@@ -7,7 +7,8 @@ import org.eclipse.paho.client.mqttv3.MqttClient
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
-import se.hkr.smarthouse.mqtt.responses.MqttResponse
+import se.hkr.smarthouse.mqtt.responses.MqttConnectionResponse
+import se.hkr.smarthouse.util.Constants
 import java.util.*
 
 object MqttConnection {
@@ -16,19 +17,18 @@ object MqttConnection {
 
     fun publish(
         topic: String,
-        message: String,
-        qos: Int
-    ): LiveData<MqttResponse> {
-        val liveData = MutableLiveData<MqttResponse>()
+        message: String
+    ): LiveData<MqttConnectionResponse> {
+        val liveData = MutableLiveData<MqttConnectionResponse>()
         try {
-            Log.d(TAG, "MqttConnection: publishing: topic: $topic, deviceList: $message, qos: $qos")
+            Log.d(TAG, "MqttConnection: publishing: topic: $topic, message: $message")
             val mqttMessage = MqttMessage(message.toByteArray())
-            mqttMessage.qos = qos
+            mqttMessage.qos = Constants.QOS
             mqttClient.publish(topic, mqttMessage)
-            liveData.value = MqttResponse(true)
+            liveData.value = MqttConnectionResponse(true)
             Log.d(TAG, "Mqtt connection success")
         } catch (e: Exception) {
-            liveData.value = MqttResponse(false)
+            liveData.value = MqttConnectionResponse(false)
             Log.e(TAG, "Mqtt connection failure")
             Log.e(TAG, "Exception stack trace: ", e)
         }
@@ -39,8 +39,8 @@ object MqttConnection {
         username: String,
         password: String,
         hostUrl: String
-    ): LiveData<MqttResponse> {
-        val liveData = MutableLiveData<MqttResponse>()
+    ): LiveData<MqttConnectionResponse> {
+        val liveData = MutableLiveData<MqttConnectionResponse>()
         try {
             mqttClient = MqttClient(
                 hostUrl,
@@ -53,10 +53,10 @@ object MqttConnection {
             // connectionOptions.userName = username
             // connectionOptions.password = password.toCharArray()
             mqttClient.connect(connectionOptions)
-            liveData.value = MqttResponse(true)
+            liveData.value = MqttConnectionResponse(true)
             Log.d(TAG, "Mqtt connection success")
         } catch (e: Exception) {
-            liveData.value = MqttResponse(false)
+            liveData.value = MqttConnectionResponse(false)
             Log.e(TAG, "Mqtt connection failure")
             Log.e(TAG, "Exception stack trace: ", e)
         }

--- a/app/src/main/java/se/hkr/smarthouse/mqtt/MqttConnection.kt
+++ b/app/src/main/java/se/hkr/smarthouse/mqtt/MqttConnection.kt
@@ -8,7 +8,7 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 import se.hkr.smarthouse.mqtt.responses.MqttResponse
-import java.util.UUID
+import java.util.*
 
 object MqttConnection {
     val TAG: String = "AppDebug"
@@ -21,7 +21,7 @@ object MqttConnection {
     ): LiveData<MqttResponse> {
         val liveData = MutableLiveData<MqttResponse>()
         try {
-            Log.d(TAG, "MqttConnection: publishing: topic: $topic, message: $message, qos: $qos")
+            Log.d(TAG, "MqttConnection: publishing: topic: $topic, deviceList: $message, qos: $qos")
             val mqttMessage = MqttMessage(message.toByteArray())
             mqttMessage.qos = qos
             mqttClient.publish(topic, mqttMessage)

--- a/app/src/main/java/se/hkr/smarthouse/mqtt/Topics.kt
+++ b/app/src/main/java/se/hkr/smarthouse/mqtt/Topics.kt
@@ -1,0 +1,41 @@
+package se.hkr.smarthouse.mqtt
+
+import se.hkr.smarthouse.models.Device
+
+object Topics {
+    val hashMap: HashMap<String, Any> = hashMapOf(
+        "livingRoomBluetoothFan" to Device.InteractiveOnOff,
+        "livingRoomLamp" to Device.InteractiveOnOff,
+        "livingRoomBluetoothCeilingLight" to Device.InteractiveOnOff,
+        "atticFan" to Device.InteractiveOnOff,
+        "kitchenFireAlarm" to Device.ObservableOnOff,
+        "kitchenWaterLeakageSensor" to Device.ObservableOnOff,
+        "livingRoomWindowSensor" to Device.ObservableOnOff,
+        "outsideAlarm" to Device.ObservableOnOff,
+        "outsideSecurityLight" to Device.ObservableOnOff,
+        "outsideTwilightSensor" to Device.ObservableOnOff,
+        "livingRoomHeater" to Device.InteractiveTemperature,
+        "atticHeater" to Device.InteractiveTemperature,
+        "livingRoomTempSensor" to Device.ObservableTemperature,
+        "outsideTempSensor" to Device.ObservableTemperature,
+        "rgbLight" to Device.InteractiveRgb
+    )
+
+    val allTopicsList = mutableListOf(
+        Device.InteractiveOnOff("livingRoomBluetoothFan"),
+        Device.InteractiveOnOff("livingRoomLamp"),
+        Device.InteractiveOnOff("livingRoomBluetoothCeilingLight"),
+        Device.InteractiveOnOff("atticFan"),
+        Device.ObservableOnOff("kitchenFireAlarm"),
+        Device.ObservableOnOff("kitchenWaterLeakageSensor"),
+        Device.ObservableOnOff("livingRoomWindowSensor"),
+        Device.ObservableOnOff("outsideAlarm"),
+        Device.ObservableOnOff("outsideSecurityLight"),
+        Device.ObservableOnOff("outsideTwilightSensor"),
+        Device.InteractiveTemperature("livingRoomHeater"),
+        Device.InteractiveTemperature("atticHeater"),
+        Device.ObservableTemperature("livingRoomTempSensor"),
+        Device.ObservableTemperature("outsideTempSensor"),
+        Device.InteractiveRgb("rgbLight", 20, 40, 50)
+    )
+}

--- a/app/src/main/java/se/hkr/smarthouse/mqtt/Topics.kt
+++ b/app/src/main/java/se/hkr/smarthouse/mqtt/Topics.kt
@@ -1,6 +1,7 @@
 package se.hkr.smarthouse.mqtt
 
 import se.hkr.smarthouse.models.Device
+import se.hkr.smarthouse.util.Constants
 
 object Topics {
     // TODO make it somehow to "Contains" lamp for example, not necessarily just "lamp" might need
@@ -22,24 +23,24 @@ object Topics {
     )
 
     val allTopicsList = mutableListOf<Device>(
-        Device.InteractiveOnOff("Smarthome/livingRoom/bluetoothFan"),
-        Device.InteractiveOnOff("Smarthome/livingRoom/lamp"),
-        Device.InteractiveOnOff("Smarthome/livingRoom/bluetoothCeilingLight"),
-        Device.ObservableOnOff("Smarthome/livingRoom/windowSensor"),
-        Device.InteractiveTemperature("Smarthome/livingRoom/heater"),
-        Device.ObservableTemperature("Smarthome/livingRoom/temperatureSensor"),
+        Device.InteractiveOnOff("${Constants.BASE_TOPIC}/livingRoom/bluetoothFan"),
+        Device.InteractiveOnOff("${Constants.BASE_TOPIC}/livingRoom/lamp"),
+        Device.InteractiveOnOff("${Constants.BASE_TOPIC}/livingRoom/bluetoothCeilingLight"),
+        Device.ObservableOnOff("${Constants.BASE_TOPIC}/livingRoom/windowSensor"),
+        Device.InteractiveTemperature("${Constants.BASE_TOPIC}/livingRoom/heater"),
+        Device.ObservableTemperature("${Constants.BASE_TOPIC}/livingRoom/temperatureSensor"),
 
-        Device.InteractiveOnOff("Smarthome/attic/fan"),
-        Device.InteractiveTemperature("Smarthome/attic/heater"),
+        Device.InteractiveOnOff("${Constants.BASE_TOPIC}/attic/fan"),
+        Device.InteractiveTemperature("${Constants.BASE_TOPIC}/attic/heater"),
 
-        Device.ObservableOnOff("Smarthome/kitchen/fireAlarm"),
-        Device.ObservableOnOff("Smarthome/kitchen/waterLeakageSensor"),
+        Device.ObservableOnOff("${Constants.BASE_TOPIC}/kitchen/fireAlarm"),
+        Device.ObservableOnOff("${Constants.BASE_TOPIC}/kitchen/waterLeakageSensor"),
 
-        Device.ObservableOnOff("Smarthome/outside/alarm"),
-        Device.ObservableOnOff("Smarthome/outside/securityLight"),
-        Device.ObservableOnOff("Smarthome/outside/twilightSensor"),
-        Device.ObservableTemperature("Smarthome/outside/temperatureSensor"),
+        Device.ObservableOnOff("${Constants.BASE_TOPIC}/outside/alarm"),
+        Device.ObservableOnOff("${Constants.BASE_TOPIC}/outside/securityLight"),
+        Device.ObservableOnOff("${Constants.BASE_TOPIC}/outside/twilightSensor"),
+        Device.ObservableTemperature("${Constants.BASE_TOPIC}/outside/temperatureSensor"),
 
-        Device.InteractiveRgb("Smarthome/rgbLight", 20, 40, 50)
+        Device.InteractiveRgb("${Constants.BASE_TOPIC}/rgbLight", 20, 40, 50)
     )
 }

--- a/app/src/main/java/se/hkr/smarthouse/mqtt/Topics.kt
+++ b/app/src/main/java/se/hkr/smarthouse/mqtt/Topics.kt
@@ -3,39 +3,43 @@ package se.hkr.smarthouse.mqtt
 import se.hkr.smarthouse.models.Device
 
 object Topics {
+    // TODO make it somehow to "Contains" lamp for example, not necessarily just "lamp" might need
+    //  to be done on a layer above this, since hashMap needs to be strict with the key values
     val hashMap: HashMap<String, Any> = hashMapOf(
-        "livingRoomBluetoothFan" to Device.InteractiveOnOff,
-        "livingRoomLamp" to Device.InteractiveOnOff,
-        "livingRoomBluetoothCeilingLight" to Device.InteractiveOnOff,
-        "atticFan" to Device.InteractiveOnOff,
-        "kitchenFireAlarm" to Device.ObservableOnOff,
-        "kitchenWaterLeakageSensor" to Device.ObservableOnOff,
-        "livingRoomWindowSensor" to Device.ObservableOnOff,
-        "outsideAlarm" to Device.ObservableOnOff,
-        "outsideSecurityLight" to Device.ObservableOnOff,
-        "outsideTwilightSensor" to Device.ObservableOnOff,
-        "livingRoomHeater" to Device.InteractiveTemperature,
-        "atticHeater" to Device.InteractiveTemperature,
-        "livingRoomTempSensor" to Device.ObservableTemperature,
-        "outsideTempSensor" to Device.ObservableTemperature,
+        "bluetoothFan" to Device.InteractiveOnOff,
+        "lamp" to Device.InteractiveOnOff,
+        "bluetoothCeilingLight" to Device.InteractiveOnOff,
+        "fan" to Device.InteractiveOnOff,
+        "fireAlarm" to Device.ObservableOnOff,
+        "waterLeakageSensor" to Device.ObservableOnOff,
+        "windowSensor" to Device.ObservableOnOff,
+        "alarm" to Device.ObservableOnOff,
+        "securityLight" to Device.ObservableOnOff,
+        "twilightSensor" to Device.ObservableOnOff,
+        "heater" to Device.InteractiveTemperature,
+        "temperatureSensor" to Device.ObservableTemperature,
         "rgbLight" to Device.InteractiveRgb
     )
 
-    val allTopicsList = mutableListOf(
-        Device.InteractiveOnOff("livingRoomBluetoothFan"),
-        Device.InteractiveOnOff("livingRoomLamp"),
-        Device.InteractiveOnOff("livingRoomBluetoothCeilingLight"),
-        Device.InteractiveOnOff("atticFan"),
-        Device.ObservableOnOff("kitchenFireAlarm"),
-        Device.ObservableOnOff("kitchenWaterLeakageSensor"),
-        Device.ObservableOnOff("livingRoomWindowSensor"),
-        Device.ObservableOnOff("outsideAlarm"),
-        Device.ObservableOnOff("outsideSecurityLight"),
-        Device.ObservableOnOff("outsideTwilightSensor"),
-        Device.InteractiveTemperature("livingRoomHeater"),
-        Device.InteractiveTemperature("atticHeater"),
-        Device.ObservableTemperature("livingRoomTempSensor"),
-        Device.ObservableTemperature("outsideTempSensor"),
-        Device.InteractiveRgb("rgbLight", 20, 40, 50)
+    val allTopicsList = mutableListOf<Device>(
+        Device.InteractiveOnOff("Smarthome/livingRoom/bluetoothFan"),
+        Device.InteractiveOnOff("Smarthome/livingRoom/lamp"),
+        Device.InteractiveOnOff("Smarthome/livingRoom/bluetoothCeilingLight"),
+        Device.ObservableOnOff("Smarthome/livingRoom/windowSensor"),
+        Device.InteractiveTemperature("Smarthome/livingRoom/heater"),
+        Device.ObservableTemperature("Smarthome/livingRoom/temperatureSensor"),
+
+        Device.InteractiveOnOff("Smarthome/attic/fan"),
+        Device.InteractiveTemperature("Smarthome/attic/heater"),
+
+        Device.ObservableOnOff("Smarthome/kitchen/fireAlarm"),
+        Device.ObservableOnOff("Smarthome/kitchen/waterLeakageSensor"),
+
+        Device.ObservableOnOff("Smarthome/outside/alarm"),
+        Device.ObservableOnOff("Smarthome/outside/securityLight"),
+        Device.ObservableOnOff("Smarthome/outside/twilightSensor"),
+        Device.ObservableTemperature("Smarthome/outside/temperatureSensor"),
+
+        Device.InteractiveRgb("Smarthome/rgbLight", 20, 40, 50)
     )
 }

--- a/app/src/main/java/se/hkr/smarthouse/mqtt/responses/MqttConnectionResponse.kt
+++ b/app/src/main/java/se/hkr/smarthouse/mqtt/responses/MqttConnectionResponse.kt
@@ -1,9 +1,9 @@
 package se.hkr.smarthouse.mqtt.responses
 
-class MqttResponse(
+class MqttConnectionResponse(
     var successful: Boolean = false
 ) {
     override fun toString(): String {
-        return "MqttResponse(successful=$successful)"
+        return "MqttConnectionResponse(successful=$successful)"
     }
 }

--- a/app/src/main/java/se/hkr/smarthouse/repository/NetworkBoundResource.kt
+++ b/app/src/main/java/se/hkr/smarthouse/repository/NetworkBoundResource.kt
@@ -3,17 +3,9 @@ package se.hkr.smarthouse.repository
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
-import kotlinx.coroutines.CompletableJob
-import kotlinx.coroutines.CompletionHandler
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import se.hkr.smarthouse.ui.DataState
 import se.hkr.smarthouse.ui.Response
 import se.hkr.smarthouse.ui.ResponseType
@@ -78,10 +70,18 @@ abstract class NetworkBoundResource<ResponseObject, ViewStateType>(
                     if (job.isCancelled) {
                         Log.e("TAG", "NetworkBoundResource: Job has been cancelled.")
                         cause?.let {
-                            onErrorReturn(it.message, false, true)
-                        } ?: onErrorReturn(ERROR_UNKNOWN, false, true)
+                            onErrorReturn(
+                                errorMessage = it.message,
+                                shouldUseDialog = false,
+                                shouldUseToast = true
+                            )
+                        } ?: onErrorReturn(
+                            errorMessage = ERROR_UNKNOWN,
+                            shouldUseDialog = false,
+                            shouldUseToast = true
+                        )
                     } else if (job.isCompleted) {
-                        Log.e(TAG, "NetworkBoundResource: Job has been completed...")
+                        Log.i(TAG, "NetworkBoundResource: Job has been completed...")
                         //Do nothing. Should be handled already.
                     }
                 }

--- a/app/src/main/java/se/hkr/smarthouse/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/se/hkr/smarthouse/repository/auth/AuthRepository.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LiveData
 import kotlinx.coroutines.Job
 import se.hkr.smarthouse.models.AccountCredentials
 import se.hkr.smarthouse.mqtt.MqttConnection
-import se.hkr.smarthouse.mqtt.responses.MqttResponse
+import se.hkr.smarthouse.mqtt.responses.MqttConnectionResponse
 import se.hkr.smarthouse.persistence.AccountCredentialsDao
 import se.hkr.smarthouse.repository.NetworkBoundResource
 import se.hkr.smarthouse.session.SessionManager
@@ -34,13 +34,17 @@ constructor(
         if (loginFieldErrors != LoginFields.LoginError.none()) {
             return returnErrorResponse(loginFieldErrors, ResponseType.Dialog())
         }
-        return object : NetworkBoundResource<MqttResponse, AuthViewState>(
+        return object : NetworkBoundResource<MqttConnectionResponse, AuthViewState>(
             sessionManager.isConnectedToTheInternet()
         ) {
-            override fun handleResponse(response: MqttResponse) {
+            override fun handleResponse(response: MqttConnectionResponse) {
                 Log.d(TAG, "handle response: $response")
                 if (!response.successful) {
-                    return onErrorReturn("Connection Failed", true, false)
+                    return onErrorReturn(
+                        errorMessage = "Connection Failed",
+                        shouldUseDialog = true,
+                        shouldUseToast = false
+                    )
                 }
                 onCompleteJob(
                     DataState.data(
@@ -56,7 +60,7 @@ constructor(
                 )
             }
 
-            override fun createCall(): LiveData<MqttResponse> {
+            override fun createCall(): LiveData<MqttConnectionResponse> {
                 return MqttConnection.connect(
                     username = username,
                     password = password,

--- a/app/src/main/java/se/hkr/smarthouse/ui/BaseViewModel.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/BaseViewModel.kt
@@ -23,6 +23,10 @@ abstract class BaseViewModel<StateEvent, ViewState> : ViewModel() {
         _stateEvent.value = event
     }
 
+    fun setViewState(viewState: ViewState) {
+        _viewState.value = viewState
+    }
+
     fun getCurrentViewStateOrNew(): ViewState {
         return viewState.value?.let {
             it

--- a/app/src/main/java/se/hkr/smarthouse/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/auth/AuthViewModel.kt
@@ -38,7 +38,7 @@ constructor(
             return
         }
         newViewState.loginFields = loginFields
-        _viewState.value = newViewState
+        setViewState(newViewState)
     }
 
     fun setAccountCredentials(accountCredentials: AccountCredentials) {
@@ -47,7 +47,7 @@ constructor(
             return
         }
         newViewState.accountCredentials = accountCredentials
-        _viewState.value = newViewState
+        setViewState(newViewState)
     }
 
     fun cancelActiveJobs() {

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/DeviceListAdapter.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/DeviceListAdapter.kt
@@ -1,0 +1,262 @@
+package se.hkr.smarthouse.ui.main
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.device_list_item_header.view.*
+import kotlinx.android.synthetic.main.device_list_item_interactive_on_off.view.*
+import kotlinx.android.synthetic.main.device_list_item_interactive_rgb.view.*
+import kotlinx.android.synthetic.main.device_list_item_interactive_temperature.view.*
+import se.hkr.smarthouse.R
+import se.hkr.smarthouse.models.*
+
+class DeviceListAdapter(
+    private val clickInteraction: ClickInteraction? = null,
+    private val switchInteraction: SwitchInteraction? = null,
+    private val sliderInteraction: SliderInteraction? = null
+) : RecyclerView.Adapter<DeviceListAdapter.BaseViewHolder<*>>() {
+    companion object {
+        const val TAG = "AppDebug"
+    }
+
+    private val diffCallback = object : DiffUtil.ItemCallback<Device>() {
+        override fun areItemsTheSame(oldItem: Device, newItem: Device): Boolean {
+            return oldItem.topic == newItem.topic
+        }
+
+        override fun areContentsTheSame(oldItem: Device, newItem: Device): Boolean {
+            if (oldItem::class != newItem::class) {
+                return false
+            }
+            return when (oldItem) {
+                is InteractiveOnOff -> newItem as InteractiveOnOff == oldItem
+                is ObservableOnOff -> newItem as ObservableOnOff == oldItem
+                is InteractiveTemperature -> newItem as InteractiveTemperature == oldItem
+                is ObservableTemperature -> newItem as ObservableTemperature == oldItem
+                is InteractiveRgb -> newItem as InteractiveRgb == oldItem
+            }
+        }
+    }
+    private val differ = AsyncListDiffer(this, diffCallback)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<*> {
+        return when (viewType) {
+            InteractiveOnOff.IDENTIFIER -> {
+                InteractiveOnOffViewHolder(
+                    LayoutInflater.from(parent.context).inflate(
+                        R.layout.device_list_item_interactive_on_off, parent, false
+                    ),
+                    clickInteraction,
+                    switchInteraction
+                )
+            }
+            ObservableOnOff.IDENTIFIER -> {
+                ObservableOnOffViewHolder(
+                    LayoutInflater.from(parent.context).inflate(
+                        R.layout.device_list_item_observable_on_off, parent, false
+                    )
+                )
+            }
+            InteractiveTemperature.IDENTIFIER -> {
+                InteractiveTemperatureViewHolder(
+                    LayoutInflater.from(parent.context).inflate(
+                        R.layout.device_list_item_interactive_temperature, parent, false
+                    ),
+                    clickInteraction,
+                    sliderInteraction
+                )
+            }
+            /*ObservableTemperature.IDENTIFIER -> {
+
+            }*/
+            InteractiveRgb.IDENTIFIER -> {
+                InteractiveRgbViewHolder(
+                    LayoutInflater.from(parent.context).inflate(
+                        R.layout.device_list_item_interactive_rgb, parent, false
+                    ),
+                    clickInteraction
+                )
+            }
+            else -> EmptyViewHolder(
+                LayoutInflater.from(parent.context).inflate(
+                    R.layout.device_list_item_empty, parent, false
+                )
+            )
+        }
+    }
+
+    override fun onBindViewHolder(holder: BaseViewHolder<*>, position: Int) {
+        val element = differ.currentList[position]
+        when (holder) {
+            is InteractiveOnOffViewHolder -> {
+                holder.bind(element as InteractiveOnOff)
+            }
+            is ObservableOnOffViewHolder -> {
+                holder.bind(element as ObservableOnOff)
+            }
+            is InteractiveTemperatureViewHolder -> {
+            }
+            /*is ObservableTemperatureViewHolder -> {
+
+            }*/
+            is InteractiveRgbViewHolder -> {
+                holder.bind(element as InteractiveRgb)
+            }
+            is EmptyViewHolder -> {
+                holder.bind(element)
+            }
+            else -> throw IllegalArgumentException("Illegal bind view holder")
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (differ.currentList[position]) {
+            is InteractiveOnOff -> InteractiveOnOff.IDENTIFIER
+            is ObservableOnOff -> ObservableOnOff.IDENTIFIER
+            is InteractiveTemperature -> InteractiveTemperature.IDENTIFIER
+            is ObservableTemperature -> ObservableTemperature.IDENTIFIER
+            is InteractiveRgb -> InteractiveRgb.IDENTIFIER
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return differ.currentList.size
+    }
+
+    fun submitList(list: List<Device>) {
+        differ.submitList(list)
+    }
+
+    inner class InteractiveOnOffViewHolder
+    constructor(
+        itemView: View,
+        private val clickInteraction: ClickInteraction?,
+        private val switchInteraction: SwitchInteraction?
+    ) : BaseViewHolder<Device>(itemView) {
+        override fun bind(item: Device) = with(itemView) {
+            val currentItem = item as InteractiveOnOff
+            Log.d(TAG, "Binding interactive on/off: $currentItem")
+            itemView.setOnClickListener {
+                clickInteraction?.onItemSelected(adapterPosition, currentItem)
+            }
+            itemView.deviceSwitch.setOnClickListener {
+                //TODO check if we need to update the value here on in the viewState
+                switchInteraction?.onSwitchClicked(deviceSwitch.isChecked, currentItem)
+            }
+            itemView.deviceName.text = currentItem.getName()
+            itemView.deviceTopic.text = currentItem.topic
+            itemView.deviceSwitch.isChecked = currentItem.state
+        }
+    }
+
+    inner class ObservableOnOffViewHolder
+    constructor(
+        itemView: View
+    ) : BaseViewHolder<Device>(itemView) {
+        override fun bind(item: Device) = with(itemView) {
+            val currentItem = item as ObservableOnOff
+            Log.d(TAG, "Binding observable on/off: $currentItem")
+            itemView.deviceName.text = currentItem.getName()
+            itemView.deviceTopic.text = currentItem.topic
+            itemView.deviceSwitch.isChecked = currentItem.state
+        }
+    }
+
+    inner class InteractiveTemperatureViewHolder
+    constructor(
+        itemView: View,
+        private val clickInteraction: ClickInteraction?,
+        private val sliderInteraction: SliderInteraction?
+    ) : BaseViewHolder<Device>(itemView) {
+        override fun bind(item: Device) = with(itemView) {
+            val currentItem = item as InteractiveTemperature
+            Log.d(TAG, "Binding slider: $currentItem")
+            deviceSlider.setOnChangeListener { slider, value ->
+                Log.d(TAG, "Slider: $slider, changed the value to $value")
+                sliderInteraction?.onSliderUpdated(value.toInt(), currentItem)
+            }
+            itemView.setOnClickListener {
+                clickInteraction?.onItemSelected(adapterPosition, currentItem)
+            }
+
+            itemView.deviceName.text = currentItem.getName()
+            itemView.deviceTopic.text = currentItem.topic
+            itemView.deviceSlider.value = currentItem.temperature
+        }
+    }
+
+    inner class InteractiveRgbViewHolder
+    constructor(
+        itemView: View,
+        private val clickInteraction: ClickInteraction?
+    ) : BaseViewHolder<Device>(itemView) {
+        override fun bind(item: Device) = with(itemView) {
+            val currentItem = item as InteractiveRgb
+            Log.d(TAG, "Binding rgb: $currentItem")
+            itemView.deviceSliderRed.setOnChangeListener { _, value ->
+                currentItem.red = value.toInt()
+                itemView.textViewRedValue.text = value.toInt().toString()
+            }
+            itemView.deviceSliderGreen.setOnChangeListener { _, value ->
+                currentItem.green = value.toInt()
+                itemView.textViewGreenValue.text = value.toInt().toString()
+            }
+            itemView.deviceSliderBlue.setOnChangeListener { _, value ->
+                currentItem.blue = value.toInt()
+                itemView.textViewBlueValue.text = value.toInt().toString()
+            }
+            itemView.deviceSliderRed.setOnTouchListener { _, event ->
+                if (event?.action == MotionEvent.ACTION_UP) {
+                    //todo send event back to fragment
+                }
+                false
+            }
+            itemView.deviceSliderGreen.setOnChangeListener { _, value ->
+                currentItem.green = value.toInt()
+            }
+            itemView.deviceSliderBlue.setOnChangeListener { _, value ->
+                currentItem.blue = value.toInt()
+            }
+            itemView.setOnClickListener {
+                clickInteraction?.onItemSelected(adapterPosition, currentItem)
+            }
+
+            itemView.deviceName.text = currentItem.getName()
+            itemView.deviceTopic.text = currentItem.topic
+            itemView.deviceSliderRed.value = currentItem.red.toFloat()
+            itemView.deviceSliderGreen.value = currentItem.green.toFloat()
+            itemView.deviceSliderBlue.value = currentItem.blue.toFloat()
+        }
+    }
+
+    inner class EmptyViewHolder
+    constructor(
+        itemView: View
+    ) : BaseViewHolder<Device>(itemView) {
+        override fun bind(item: Device) {
+        }
+    }
+
+    abstract class BaseViewHolder<T>(
+        itemView: View
+    ) : RecyclerView.ViewHolder(itemView) {
+        abstract fun bind(item: T)
+    }
+
+    interface ClickInteraction {
+        fun onItemSelected(position: Int, item: Device)
+    }
+
+    interface SwitchInteraction {
+        fun onSwitchClicked(state: Boolean, item: Device)
+    }
+
+    interface SliderInteraction {
+        fun onSliderUpdated(value: Int, item: Device)
+    }
+}

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/DeviceListAdapter.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/DeviceListAdapter.kt
@@ -62,7 +62,20 @@ class DeviceListAdapter(
             }
         }
     }
-    private val differ = AsyncListDiffer(this, diffCallback)
+
+    private val differ = object : AsyncListDiffer<Device>(this, diffCallback) {
+        // Have to override because if the list send to submitList is == to the old list, which
+        // is true since we are also updating the local variable whenever there is a change. We get
+        // around it by sending a copy of the list which does not return true on the == operation
+        // and therefore continues on the method and triggers the notifyDataSetChanged()
+        override fun submitList(newList: List<Device>?, commitCallback: Runnable?) {
+            super.submitList(newList?.toList(), commitCallback)
+        }
+
+        override fun submitList(newList: MutableList<Device>?) {
+            super.submitList(newList?.toList())
+        }
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<*> {
         return when (viewType) {
@@ -185,7 +198,7 @@ class DeviceListAdapter(
             itemView.deviceSwitch.isChecked = currentItem.state
             itemView.deviceSwitch.setOnClickListener {
                 currentItem.state = itemView.deviceSwitch.isChecked
-                interaction.onStateChanged(currentItem)
+                interaction.onDeviceStateChanged(currentItem)
             }
         }
     }
@@ -222,7 +235,7 @@ class DeviceListAdapter(
             itemView.deviceSlider.setOnTouchListener { _, event ->
                 if (event?.action == MotionEvent.ACTION_UP) {
                     Log.d(TAG, "Slider released, sending new value ${currentItem.temperature}")
-                    interaction.onStateChanged(currentItem)
+                    interaction.onDeviceStateChanged(currentItem)
                 }
                 false
             }
@@ -274,21 +287,21 @@ class DeviceListAdapter(
             itemView.deviceSliderRed.setOnTouchListener { _, event ->
                 if (event?.action == MotionEvent.ACTION_UP) {
                     Log.d(TAG, "Slider released, sending new value ${currentItem.red}")
-                    interaction.onStateChanged(currentItem)
+                    interaction.onDeviceStateChanged(currentItem)
                 }
                 false
             }
             itemView.deviceSliderGreen.setOnTouchListener { _, event ->
                 if (event?.action == MotionEvent.ACTION_UP) {
                     Log.d(TAG, "Slider released, sending new value ${currentItem.green}")
-                    interaction.onStateChanged(currentItem)
+                    interaction.onDeviceStateChanged(currentItem)
                 }
                 false
             }
             itemView.deviceSliderBlue.setOnTouchListener { _, event ->
                 if (event?.action == MotionEvent.ACTION_UP) {
                     Log.d(TAG, "Slider released, sending new value ${currentItem.blue}")
-                    interaction.onStateChanged(currentItem)
+                    interaction.onDeviceStateChanged(currentItem)
                 }
                 false
             }
@@ -302,6 +315,6 @@ class DeviceListAdapter(
     }
 
     interface Interaction {
-        fun onStateChanged(item: Device)
+        fun onDeviceStateChanged(item: Device)
     }
 }

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
@@ -27,6 +27,7 @@ class MainActivity : BaseActivity() {
             sessionManager.logout()
         }
         subscribeObservers()
+        initializeMqttSubscription()
         supportFragmentManager.beginTransaction()
             .replace(
                 R.id.fragment_container,
@@ -42,7 +43,7 @@ class MainActivity : BaseActivity() {
             dataState.data?.let { data ->
                 data.data?.let { dataEvent ->
                     dataEvent.getContentIfNotHandled()?.let { eventContent ->
-                        // TODO subscribeFields?
+                        // TODO subscribeTopics?
                         /*eventContent.publishFields?.let { publishFields ->
                             Log.d(TAG, "MainActivity: new publishFields: $publishFields")
                             viewModel.setPublishFields(publishFields)
@@ -67,6 +68,10 @@ class MainActivity : BaseActivity() {
                 navAuthActivity()
             }
         })
+    }
+
+    private fun initializeMqttSubscription() {
+        viewModel.initializeMqttSubscription()
     }
 
     private fun navAuthActivity() {

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import kotlinx.android.synthetic.main.activity_main.*
 import se.hkr.smarthouse.R
-import se.hkr.smarthouse.mqtt.MqttConnection
 import se.hkr.smarthouse.ui.BaseActivity
 import se.hkr.smarthouse.ui.auth.AuthActivity
 import se.hkr.smarthouse.util.setVisibility
@@ -44,10 +43,10 @@ class MainActivity : BaseActivity() {
                 data.data?.let { dataEvent ->
                     dataEvent.getContentIfNotHandled()?.let { eventContent ->
                         // TODO subscribeFields?
-                        eventContent.publishFields?.let { publishFields ->
+                        /*eventContent.publishFields?.let { publishFields ->
                             Log.d(TAG, "MainActivity: new publishFields: $publishFields")
                             viewModel.setPublishFields(publishFields)
-                        }
+                        }*/
                         eventContent.deviceFields?.let { devicesState ->
                             Log.d(TAG, "MainActivity: new deviceFields: $devicesState")
                             viewModel.setDevicesFields(devicesState)
@@ -56,17 +55,8 @@ class MainActivity : BaseActivity() {
                 }
             }
         })
-        viewModel.viewState.observe(this, Observer { authViewState ->
-            Log.d(TAG, "MainActivity: viewState changed to: $authViewState")
-            authViewState.publishFields?.let { publishFields ->
-                publishFields.topic?.let { topic ->
-                    publishFields.message?.let { message ->
-                        publishFields.qos.let { qos ->
-                            MqttConnection.publish(topic, message, qos)
-                        }
-                    }
-                }
-            }
+        viewModel.viewState.observe(this, Observer { mainViewState ->
+            Log.d(TAG, "MainActivity: viewState changed to: $mainViewState")
         })
         sessionManager.cachedAccountCredentials.observe(this, Observer { accountCredentials ->
             Log.d(TAG, "MainActivity: Account credentials observed change: $accountCredentials")

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
@@ -28,7 +28,6 @@ class MainActivity : BaseActivity() {
             sessionManager.logout()
         }
         subscribeObservers()
-        // TODO use nav for it instead of this simple inflation
         supportFragmentManager.beginTransaction()
             .replace(
                 R.id.fragment_container,
@@ -44,9 +43,14 @@ class MainActivity : BaseActivity() {
             dataState.data?.let { data ->
                 data.data?.let { dataEvent ->
                     dataEvent.getContentIfNotHandled()?.let { eventContent ->
+                        // TODO subscribeFields?
                         eventContent.publishFields?.let { publishFields ->
                             Log.d(TAG, "MainActivity: new publishFields: $publishFields")
                             viewModel.setPublishFields(publishFields)
+                        }
+                        eventContent.deviceFields?.let { devicesState ->
+                            Log.d(TAG, "MainActivity: new deviceFields: $devicesState")
+                            viewModel.setDevicesFields(devicesState)
                         }
                     }
                 }
@@ -55,13 +59,12 @@ class MainActivity : BaseActivity() {
         viewModel.viewState.observe(this, Observer { authViewState ->
             Log.d(TAG, "MainActivity: viewState changed to: $authViewState")
             authViewState.publishFields?.let { publishFields ->
-                publishFields.topic?.let {
-                    MqttConnection.publish(
-                        // TODO not just !!, check how to fix this properly
-                        publishFields.topic!!,
-                        publishFields.message!!,
-                        publishFields.qos
-                    )
+                publishFields.topic?.let { topic ->
+                    publishFields.message?.let { message ->
+                        publishFields.qos.let { qos ->
+                            MqttConnection.publish(topic, message, qos)
+                        }
+                    }
                 }
             }
         })

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainActivity.kt
@@ -32,8 +32,8 @@ class MainActivity : BaseActivity() {
         supportFragmentManager.beginTransaction()
             .replace(
                 R.id.fragment_container,
-                HouseFragment(),
-                "HouseFragment"
+                MainFragment(),
+                "MainFragment"
             ).commit()
     }
 

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainFragment.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainFragment.kt
@@ -7,29 +7,34 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.fragment_house.*
+import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.android.synthetic.main.fragment_main.*
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import se.hkr.smarthouse.R
+import se.hkr.smarthouse.models.*
 import se.hkr.smarthouse.ui.main.state.MainStateEvent
+import se.hkr.smarthouse.util.TopSpacingItemDecoration
 
-class HouseFragment : BaseMainFragment() {
+class MainFragment : BaseMainFragment() {
     private val switchStateListener: CompoundButton.OnCheckedChangeListener =
         CompoundButton.OnCheckedChangeListener { _, isChecked ->
             publishTopic(isChecked)
         }
+    private lateinit var recyclerAdapter: DeviceListAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_house, container, false)
+        return inflater.inflate(R.layout.fragment_main, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         subscribeObservers()
+        initializeRecyclerView()
         state_switch.setOnCheckedChangeListener(switchStateListener)
         subscribe_button.setOnClickListener {
             subscribeTopic()
@@ -39,12 +44,11 @@ class HouseFragment : BaseMainFragment() {
     private fun subscribeObservers() {
         viewModel.viewState.observe(viewLifecycleOwner, Observer { mainViewState ->
             try {
-                Log.d(TAG, "HouseFragment: new viewState $mainViewState")
+                Log.d(TAG, "MainFragment: new viewState $mainViewState")
                 mainViewState.lampState?.let { lampState ->
                     GlobalScope.launch(Main) {
                         state_switch.setOnCheckedChangeListener(null)
                         state_switch.isChecked = lampState.state
-                        // TODO test if the removal/adding of the listener works as intended.
                         state_switch.setOnCheckedChangeListener(switchStateListener)
                     }
                 }
@@ -52,6 +56,26 @@ class HouseFragment : BaseMainFragment() {
                 Log.e(TAG, "Exception on viewState observing on fragment", e)
             }
         })
+    }
+
+    private fun initializeRecyclerView() {
+        recyclerAdapter = DeviceListAdapter()
+        val topSpacingDecoration = TopSpacingItemDecoration(topPadding = 30)
+        mainFragmentRecyclerView.apply {
+            layoutManager = LinearLayoutManager(this@MainFragment.context)
+            adapter = recyclerAdapter
+            addItemDecoration(topSpacingDecoration)
+        }
+        //Temporary
+        recyclerAdapter.submitList(
+            listOf(
+                InteractiveOnOff("livingRoomBluetoothCeilingLight"),
+                ObservableOnOff("outsideTwilightSensor"),
+                InteractiveTemperature("livingRoomHeater"),
+                ObservableTemperature("outsideTempSensor"),
+                InteractiveRgb("rgbLight", 20, 40, 50)
+            )
+        )
     }
 
     private fun publishTopic(state: Boolean) {

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainFragment.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainFragment.kt
@@ -73,17 +73,7 @@ class MainFragment : BaseMainFragment(), DeviceListAdapter.Interaction {
         )
     }
 
-    private fun subscribeTopic() {
-        // TODO do this with event, for now just hard code it
-        //viewModel.setStateEvent(
-        //    MainStateEvent.SubscribeAttemptEvent(
-        //        input_topic.text.toString()
-        //    )
-        //)
-        viewModel.subscribeTo(topic = input_topic.text.toString())
-    }
-
-    override fun onStateChanged(item: Device) {
+    override fun onDeviceStateChanged(item: Device) {
         Log.d(TAG, "State of item ${item.getSimpleName()} changed to: $item")
         val (topic, message) = item.asMqttMessage()
         publishTopic(topic, message)

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainFragment.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainFragment.kt
@@ -5,23 +5,15 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.CompoundButton
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.fragment_main.*
-import kotlinx.coroutines.Dispatchers.Main
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import se.hkr.smarthouse.R
-import se.hkr.smarthouse.models.*
+import se.hkr.smarthouse.mqtt.Topics
 import se.hkr.smarthouse.ui.main.state.MainStateEvent
 import se.hkr.smarthouse.util.TopSpacingItemDecoration
 
 class MainFragment : BaseMainFragment() {
-    private val switchStateListener: CompoundButton.OnCheckedChangeListener =
-        CompoundButton.OnCheckedChangeListener { _, isChecked ->
-            publishTopic(isChecked)
-        }
     private lateinit var recyclerAdapter: DeviceListAdapter
 
     override fun onCreateView(
@@ -35,25 +27,18 @@ class MainFragment : BaseMainFragment() {
         super.onViewCreated(view, savedInstanceState)
         subscribeObservers()
         initializeRecyclerView()
-        state_switch.setOnCheckedChangeListener(switchStateListener)
-        subscribe_button.setOnClickListener {
-            subscribeTopic()
-        }
     }
 
     private fun subscribeObservers() {
         viewModel.viewState.observe(viewLifecycleOwner, Observer { mainViewState ->
-            try {
-                Log.d(TAG, "MainFragment: new viewState $mainViewState")
-                mainViewState.lampState?.let { lampState ->
-                    GlobalScope.launch(Main) {
-                        state_switch.setOnCheckedChangeListener(null)
-                        state_switch.isChecked = lampState.state
-                        state_switch.setOnCheckedChangeListener(switchStateListener)
+            Log.d(TAG, "MainFragment: new viewState $mainViewState")
+            mainViewState.deviceFields?.let { devicesState ->
+                devicesState.deviceList?.let { devicesList ->
+                    Log.d(TAG, "MainFragment: updating list with: $devicesList")
+                    recyclerAdapter.apply {
+                        submitList(devicesList)
                     }
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Exception on viewState observing on fragment", e)
             }
         })
     }
@@ -66,14 +51,10 @@ class MainFragment : BaseMainFragment() {
             adapter = recyclerAdapter
             addItemDecoration(topSpacingDecoration)
         }
-        //Temporary
-        recyclerAdapter.submitList(
-            listOf(
-                InteractiveOnOff("livingRoomBluetoothCeilingLight"),
-                ObservableOnOff("outsideTwilightSensor"),
-                InteractiveTemperature("livingRoomHeater"),
-                ObservableTemperature("outsideTempSensor"),
-                InteractiveRgb("rgbLight", 20, 40, 50)
+        // Initialize list with all possible hardcoded topics. Potentially make this dynamic later.
+        viewModel.setStateEvent(
+            MainStateEvent.UpdateDeviceListEvent(
+                list = Topics.allTopicsList
             )
         )
     }

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainViewModel.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainViewModel.kt
@@ -19,8 +19,7 @@ constructor(
             is MainStateEvent.PublishAttemptEvent -> {
                 mainRepository.attemptPublish(
                     stateEvent.topic,
-                    stateEvent.message,
-                    stateEvent.qos
+                    stateEvent.message
                 )
             }
             is MainStateEvent.SubscribeAttemptEvent -> {
@@ -50,7 +49,7 @@ constructor(
     }
 
     fun subscribeTo(topic: String) {
-        /*// TODO avoid breaking the MVI patter
+        /*
         Log.d(TAG, "Subscribing to $topic")
         MqttConnection.mqttClient.subscribe(topic) { subscribedTopic, messageReceived ->
             val received = messageReceived.toString()
@@ -66,7 +65,7 @@ constructor(
             return
         }
         newViewState.publishFields = publishFields
-        _viewState.value = newViewState
+        setViewState(newViewState)
     }
 
     fun setSubscribeFields(subscribeFields: SubscribeFields) {
@@ -75,7 +74,7 @@ constructor(
             return
         }
         newViewState.subscribeFields = subscribeFields
-        _viewState.value = newViewState
+        setViewState(newViewState)
     }
 
     fun setDevicesFields(deviceFields: DeviceFields) {
@@ -86,7 +85,7 @@ constructor(
         // TODO check if the ?. on the devices Fields and the !! on the list is okay to do.
         val newDevices = deviceFields.deviceList!!
         newViewState.deviceFields?.addDevice(newDevices)
-        _viewState.value = newViewState
+        setViewState(newViewState)
     }
 
     fun cancelActiveJobs() {

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/MainViewModel.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/MainViewModel.kt
@@ -1,16 +1,10 @@
 package se.hkr.smarthouse.ui.main
 
-import android.util.Log
 import androidx.lifecycle.LiveData
-import se.hkr.smarthouse.mqtt.MqttConnection
 import se.hkr.smarthouse.repository.main.MainRepository
 import se.hkr.smarthouse.ui.BaseViewModel
 import se.hkr.smarthouse.ui.DataState
-import se.hkr.smarthouse.ui.main.state.LampState
-import se.hkr.smarthouse.ui.main.state.MainStateEvent
-import se.hkr.smarthouse.ui.main.state.MainViewState
-import se.hkr.smarthouse.ui.main.state.PublishFields
-import se.hkr.smarthouse.ui.main.state.SubscribeFields
+import se.hkr.smarthouse.ui.main.state.*
 import se.hkr.smarthouse.util.AbsentLiveData
 import javax.inject.Inject
 
@@ -21,9 +15,9 @@ constructor(
 ) : BaseViewModel<MainStateEvent, MainViewState>() {
     override fun handleStateEvent(stateEvent: MainStateEvent): LiveData<DataState<MainViewState>> {
         // Temporary until the functionality is fixed
-        when (stateEvent) {
+        return when (stateEvent) {
             is MainStateEvent.PublishAttemptEvent -> {
-                return mainRepository.attemptPublish(
+                mainRepository.attemptPublish(
                     stateEvent.topic,
                     stateEvent.message,
                     stateEvent.qos
@@ -31,7 +25,22 @@ constructor(
             }
             is MainStateEvent.SubscribeAttemptEvent -> {
                 // TODO Implement subscribe using MVI as well
-                return AbsentLiveData.create<DataState<MainViewState>>()
+                AbsentLiveData.create()
+            }
+            is MainStateEvent.UpdateDeviceListEvent -> {
+                //TODO put into repository (with actual query of items?)
+                return object : LiveData<DataState<MainViewState>>() {
+                    override fun onActive() {
+                        super.onActive()
+                        value = DataState.data(
+                            data = MainViewState(
+                                deviceFields = DeviceFields(
+                                    deviceList = stateEvent.list
+                                )
+                            )
+                        )
+                    }
+                }
             }
         }
     }
@@ -41,14 +50,14 @@ constructor(
     }
 
     fun subscribeTo(topic: String) {
-        // TODO avoid breaking the MVI patter
+        /*// TODO avoid breaking the MVI patter
         Log.d(TAG, "Subscribing to $topic")
         MqttConnection.mqttClient.subscribe(topic) { subscribedTopic, messageReceived ->
             val received = messageReceived.toString()
             Log.d(TAG, "Got: $received")
             val state = received == "true"
-            _viewState.postValue(MainViewState(lampState = LampState(state)))
-        }
+            _viewState.postValue(MainViewState(deviceFields = DeviceFields(state)))
+        }*/
     }
 
     fun setPublishFields(publishFields: PublishFields) {
@@ -66,6 +75,17 @@ constructor(
             return
         }
         newViewState.subscribeFields = subscribeFields
+        _viewState.value = newViewState
+    }
+
+    fun setDevicesFields(deviceFields: DeviceFields) {
+        val newViewState = getCurrentViewStateOrNew()
+        if (newViewState.deviceFields == deviceFields) {
+            return
+        }
+        // TODO check if the ?. on the devices Fields and the !! on the list is okay to do.
+        val newDevices = deviceFields.deviceList!!
+        newViewState.deviceFields?.addDevice(newDevices)
         _viewState.value = newViewState
     }
 

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainStateEvent.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainStateEvent.kt
@@ -9,8 +9,7 @@ sealed class MainStateEvent {
 
     data class PublishAttemptEvent(
         val topic: String,
-        val message: String,
-        val qos: Int
+        val message: String
     ) : MainStateEvent()
 
     data class UpdateDeviceListEvent(

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainStateEvent.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainStateEvent.kt
@@ -1,5 +1,7 @@
 package se.hkr.smarthouse.ui.main.state
 
+import se.hkr.smarthouse.models.Device
+
 sealed class MainStateEvent {
     data class SubscribeAttemptEvent(
         val topic: String
@@ -9,5 +11,9 @@ sealed class MainStateEvent {
         val topic: String,
         val message: String,
         val qos: Int
+    ) : MainStateEvent()
+
+    data class UpdateDeviceListEvent(
+        val list: MutableList<Device>
     ) : MainStateEvent()
 }

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainViewState.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainViewState.kt
@@ -6,7 +6,7 @@ import se.hkr.smarthouse.models.Device
 const val TAG = "AppDebug"
 
 data class MainViewState(
-    var subscribeFields: SubscribeFields? = SubscribeFields(),
+    var subscribeTopics: SubscribeTopics? = SubscribeTopics(),
     var publishFields: PublishFields? = PublishFields(),
     var deviceFields: DeviceFields? = DeviceFields()
 )
@@ -43,11 +43,9 @@ data class DeviceFields(
     }
 }
 
-data class SubscribeFields(
-    var topic: String? = null
-) {
-    // TODO implement this as well
-}
+data class SubscribeTopics(
+    var topics: MutableList<String>? = null
+)
 
 data class PublishFields(
     var topic: String? = null,

--- a/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainViewState.kt
+++ b/app/src/main/java/se/hkr/smarthouse/ui/main/state/MainViewState.kt
@@ -1,14 +1,33 @@
 package se.hkr.smarthouse.ui.main.state
 
+import se.hkr.smarthouse.models.Device
+
 data class MainViewState(
     var subscribeFields: SubscribeFields? = SubscribeFields(),
     var publishFields: PublishFields? = PublishFields(),
-    var lampState: LampState? = LampState() // TODO add more (all?) states
+    var deviceFields: DeviceFields? = DeviceFields()
 )
 
-data class LampState(
-    var state: Boolean = false
-)
+data class DeviceFields(
+    var deviceList: MutableList<Device>? = null
+) {
+    fun addDevice(newDeviceList: MutableList<Device>) {
+        deviceList?.let {
+            deviceList?.forEach { oldDevice ->
+                newDeviceList.forEach { newDevice ->
+                    if (oldDevice.topic == newDevice.topic) {
+                        deviceList?.remove(oldDevice)
+                    }
+                }
+            }
+        }
+        if (deviceList == null) {
+            deviceList = newDeviceList
+            return
+        }
+        deviceList?.addAll(newDeviceList)
+    }
+}
 
 data class SubscribeFields(
     var topic: String? = null
@@ -19,7 +38,7 @@ data class SubscribeFields(
 data class PublishFields(
     var topic: String? = null,
     var message: String? = null,
-    var qos: Int = -1
+    var qos: Int = 0
 ) {
     class PublishError {
         companion object {

--- a/app/src/main/java/se/hkr/smarthouse/util/Constants.kt
+++ b/app/src/main/java/se/hkr/smarthouse/util/Constants.kt
@@ -4,9 +4,10 @@ class Constants {
     companion object {
         const val WEB_API_BASE_URL = "https://open-api.xyz/api/"
         const val NETWORK_TIMEOUT = 2000L
-        const val TESTING_NETWORK_DELAY = 1L // fake network delay for testing
-        const val TESTING_CACHE_DELAY = 0L // fake cache delay for testing
+        const val TESTING_NETWORK_DELAY = 1L // Fake network delay for testing
+        const val TESTING_CACHE_DELAY = 0L // Fake cache delay for testing
         const val LOGIN_EMAIL = "fast@fast.se"
         const val LOGIN_PASS = "fast"
+        const val QOS = 2 // We always must make sure what we send is received to improve UX
     }
 }

--- a/app/src/main/java/se/hkr/smarthouse/util/Constants.kt
+++ b/app/src/main/java/se/hkr/smarthouse/util/Constants.kt
@@ -4,7 +4,7 @@ class Constants {
     companion object {
         const val WEB_API_BASE_URL = "https://open-api.xyz/api/"
         const val NETWORK_TIMEOUT = 2000L
-        const val TESTING_NETWORK_DELAY = 1000L // fake network delay for testing
+        const val TESTING_NETWORK_DELAY = 1L // fake network delay for testing
         const val TESTING_CACHE_DELAY = 0L // fake cache delay for testing
         const val LOGIN_EMAIL = "fast@fast.se"
         const val LOGIN_PASS = "fast"

--- a/app/src/main/java/se/hkr/smarthouse/util/Constants.kt
+++ b/app/src/main/java/se/hkr/smarthouse/util/Constants.kt
@@ -8,6 +8,8 @@ class Constants {
         const val TESTING_CACHE_DELAY = 0L // Fake cache delay for testing
         const val LOGIN_EMAIL = "fast@fast.se"
         const val LOGIN_PASS = "fast"
+
+        const val BASE_TOPIC = "Smarthome"
         const val QOS = 2 // We always must make sure what we send is received to improve UX
     }
 }

--- a/app/src/main/java/se/hkr/smarthouse/util/TopSpacingItemDecoration.kt
+++ b/app/src/main/java/se/hkr/smarthouse/util/TopSpacingItemDecoration.kt
@@ -1,0 +1,17 @@
+package se.hkr.smarthouse.util
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class TopSpacingItemDecoration(private val topPadding: Int) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State
+    ) {
+        super.getItemOffsets(outRect, view, parent, state)
+        outRect.top = topPadding
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,17 +28,14 @@
         android:layout_height="match_parent"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
-        <!--Temporary!-->
         <FrameLayout
             android:id="@+id/fragment_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-
-        <FrameLayout
-            android:id="@+id/main_nav_host_fragment"
-            android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="?attr/actionBarSize" />
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <ProgressBar
             android:id="@+id/progress_bar"
@@ -53,7 +50,7 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <com.google.android.material.bottomnavigation.BottomNavigationView
+    <!--<com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation_view"
         android:layout_width="match_parent"
         android:layout_height="56dp"
@@ -64,6 +61,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:menu="@menu/main_bottom_navigation_menu" />
+        app:menu="@menu/main_bottom_navigation_menu" />-->
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/device_list_item_empty.xml
+++ b/app/src/main/res/layout/device_list_item_empty.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/deviceHeader"
+            layout="@layout/device_list_item_header"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/device_list_item_header.xml
+++ b/app/src/main/res/layout/device_list_item_header.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/deviceTopic"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:text="Topic"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/deviceName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:text="Name"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/device_list_item_interactive_on_off.xml
+++ b/app/src/main/res/layout/device_list_item_interactive_on_off.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/deviceHeader"
+            layout="@layout/device_list_item_header" />
+
+        <Switch
+            android:id="@+id/deviceSwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/deviceHeader" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/device_list_item_interactive_rgb.xml
+++ b/app/src/main/res/layout/device_list_item_interactive_rgb.xml
@@ -42,7 +42,7 @@
                 android:stepSize="1"
                 android:value="50"
                 android:valueFrom="0"
-                android:valueTo="100"
+                android:valueTo="255"
                 app:layout_constraintEnd_toStartOf="@+id/textViewRedValue"
                 app:layout_constraintStart_toEndOf="@+id/textViewRed"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -85,7 +85,7 @@
                 android:stepSize="1"
                 android:value="50"
                 android:valueFrom="0"
-                android:valueTo="100"
+                android:valueTo="255"
                 app:layout_constraintEnd_toStartOf="@+id/textViewGreenValue"
                 app:layout_constraintStart_toEndOf="@+id/textViewGreen"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -128,7 +128,7 @@
                 android:stepSize="1"
                 android:value="50"
                 android:valueFrom="0"
-                android:valueTo="100"
+                android:valueTo="255"
                 app:layout_constraintEnd_toStartOf="@+id/textViewBlueValue"
                 app:layout_constraintStart_toEndOf="@+id/textViewBlue"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/device_list_item_interactive_rgb.xml
+++ b/app/src/main/res/layout/device_list_item_interactive_rgb.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/deviceHeader"
+            layout="@layout/device_list_item_header"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/redSliderConstraintLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/deviceHeader">
+
+            <TextView
+                android:id="@+id/textViewRed"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="R"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.slider.Slider
+                android:id="@+id/deviceSliderRed"
+                style="@style/slider_red"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:stepSize="1"
+                android:value="50"
+                android:valueFrom="0"
+                android:valueTo="100"
+                app:layout_constraintEnd_toStartOf="@+id/textViewRedValue"
+                app:layout_constraintStart_toEndOf="@+id/textViewRed"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewRedValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="50"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/greenSliderConstraintLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/redSliderConstraintLayout">
+
+            <TextView
+                android:id="@+id/textViewGreen"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="G"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.slider.Slider
+                android:id="@+id/deviceSliderGreen"
+                style="@style/slider_green"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:stepSize="1"
+                android:value="50"
+                android:valueFrom="0"
+                android:valueTo="100"
+                app:layout_constraintEnd_toStartOf="@+id/textViewGreenValue"
+                app:layout_constraintStart_toEndOf="@+id/textViewGreen"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewGreenValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="50"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/blueSliderConstraintLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/greenSliderConstraintLayout">
+
+            <TextView
+                android:id="@+id/textViewBlue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="B"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.slider.Slider
+                android:id="@+id/deviceSliderBlue"
+                style="@style/slider_blue"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:stepSize="1"
+                android:value="50"
+                android:valueFrom="0"
+                android:valueTo="100"
+                app:layout_constraintEnd_toStartOf="@+id/textViewBlueValue"
+                app:layout_constraintStart_toEndOf="@+id/textViewBlue"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewBlueValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="50"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/device_list_item_interactive_temperature.xml
+++ b/app/src/main/res/layout/device_list_item_interactive_temperature.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/deviceHeader"
+            layout="@layout/device_list_item_header"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sliderConstraintLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/deviceHeader">
+
+            <TextView
+                android:id="@+id/textViewSlider"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="C°"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.slider.Slider
+                android:id="@+id/deviceSlider"
+                style="@style/slider_yellow"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:stepSize="0"
+                android:value="18"
+                android:valueFrom="-20"
+                android:valueTo="40"
+                app:layout_constraintEnd_toStartOf="@+id/textViewSliderValue"
+                app:layout_constraintStart_toEndOf="@+id/textViewSlider"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewSliderValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="18"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/device_list_item_observable_on_off.xml
+++ b/app/src/main/res/layout/device_list_item_observable_on_off.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/deviceHeader"
+            layout="@layout/device_list_item_header" />
+
+        <Switch
+            android:id="@+id/deviceSwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="20dp"
+            android:clickable="false"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/deviceHeader" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/device_list_item_observable_temperature.xml
+++ b/app/src/main/res/layout/device_list_item_observable_temperature.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/deviceHeader"
+            layout="@layout/device_list_item_header"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/sliderConstraintLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/deviceHeader">
+
+            <TextView
+                android:id="@+id/textViewSlider"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="C°"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.slider.Slider
+                android:id="@+id/deviceSlider"
+                style="@style/slider_yellow"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:clickable="false"
+                android:stepSize="0"
+                android:value="18"
+                android:valueFrom="-20"
+                android:valueTo="40"
+                app:layout_constraintEnd_toStartOf="@+id/textViewSliderValue"
+                app:layout_constraintStart_toEndOf="@+id/textViewSlider"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewSliderValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="20dp"
+                android:text="18"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -10,62 +10,7 @@
         android:id="@+id/mainFragmentRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@id/input_topic_layout"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/input_topic_layout"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:padding="16dp"
-        app:layout_constraintBottom_toTopOf="@+id/subscribe_button"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVertical"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <EditText
-            android:id="@+id/input_topic"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/topic"
-            android:inputType="text"
-            android:text="SmartHome/"
-            android:textAlignment="center"
-            android:textColor="#000" />
-
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <Button
-        android:id="@+id/subscribe_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="15dp"
-        android:background="@drawable/main_button_drawable"
-        android:text="@string/subscribe"
-        android:textAllCaps="false"
-        android:textColor="#fff"
-        android:textSize="16sp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
-
-    <Switch
-        android:id="@+id/state_switch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="@+id/input_topic_layout"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVertical"
-        app:layout_constraintTop_toTopOf="@+id/input_topic_layout">
-
-    </Switch>
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineVertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.8" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -6,19 +6,23 @@
     android:layout_height="match_parent"
     tools:context=".ui.main.MainActivity">
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/mainFragmentRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/input_topic_layout"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/input_topic_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:padding="16dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHorizontal"
+        app:layout_constraintBottom_toTopOf="@+id/subscribe_button"
         app:layout_constraintEnd_toStartOf="@+id/guidelineVertical"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHorizontal"
-        app:layout_constraintVertical_bias="0.0">
+        app:layout_constraintStart_toStartOf="parent">
 
         <EditText
             android:id="@+id/input_topic"
@@ -26,7 +30,7 @@
             android:layout_height="wrap_content"
             android:hint="@string/topic"
             android:inputType="text"
-            android:text="home/garden/fountain"
+            android:text="SmartHome/"
             android:textAlignment="center"
             android:textColor="#000" />
 
@@ -44,25 +48,18 @@
         android:textSize="16sp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/input_topic_layout" />
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <Switch
         android:id="@+id/state_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHorizontal"
+        app:layout_constraintBottom_toBottomOf="@+id/input_topic_layout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/guidelineVertical"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHorizontal">
+        app:layout_constraintTop_toTopOf="@+id/input_topic_layout">
 
     </Switch>
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHorizontal"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.5" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineVertical"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,10 +1,37 @@
 <resources>
 
-    <style name="AppTheme"
-        parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+    <style name="slider_yellow" parent="Widget.MaterialComponents.Slider">
+        <item name="activeTrackColor">#FFFF00</item>
+        <item name="inactiveTrackColor">#FFFF00</item>
+        <item name="thumbColor">#FFFF00</item>
+        <item name="android:colorPrimary">#FFFF00</item>
+    </style>
+
+    <style name="slider_red" parent="Widget.MaterialComponents.Slider">
+        <item name="activeTrackColor">#FF0000</item>
+        <item name="inactiveTrackColor">#FF0000</item>
+        <item name="thumbColor">#FF0000</item>
+        <item name="android:colorPrimary">#FF0000</item>
+    </style>
+
+    <style name="slider_green" parent="Widget.MaterialComponents.Slider">
+        <item name="activeTrackColor">#00FF00</item>
+        <item name="inactiveTrackColor">#00FF00</item>
+        <item name="thumbColor">#00FF00</item>
+        <item name="android:colorPrimary">#00FF00</item>
+    </style>
+
+    <style name="slider_blue" parent="Widget.MaterialComponents.Slider">
+        <item name="activeTrackColor">#0000FF</item>
+        <item name="inactiveTrackColor">#0000FF</item>
+        <item name="thumbColor">#0000FF</item>
+        <item name="android:colorPrimary">#0000FF</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Implement the recycler view inside main fragment to take care of showing all the available devices and handling the user interaction with them. That means whenever there is a change, it is published to the broker immediately. Subscription is also taken care of and they are updated properly whenever there is a change in the topic. Currently the first initial list is hard-coded in, but it is possible for that to be removed as long as the messages published to the MQTT broker are marked as  "Retained".